### PR TITLE
Retain the 'info string' of a fenced code block.

### DIFF
--- a/source/ceylon/markdown/core/FencedCode.ceylon
+++ b/source/ceylon/markdown/core/FencedCode.ceylon
@@ -1,4 +1,4 @@
-shared class FencedCode(String text, shared Integer fenceLevel) extends CodeBlock(text) {
+shared class FencedCode(String text, shared String infoString, shared Integer fenceLevel) extends CodeBlock(text) {
 	shared actual variable Node[] children = [];
 	
 	shared actual Type accept<Type>(Visitor<Type> visitor) => visitor.visitFencedCode(this);

--- a/source/ceylon/markdown/core/parseLine.ceylon
+++ b/source/ceylon/markdown/core/parseLine.ceylon
@@ -86,7 +86,7 @@ void parseLine(variable String line, Block parent) {
 		lineBlock = HtmlBlock(line, block.type);
 		line = "";
 	} else if (!lastBlock is FencedCode, fencedCodeblockPattern.test(line)) {
-		lineBlock = FencedCode("", line.count(('\`'.equals)));
+		lineBlock = FencedCode("", line.trimLeading((ch) => ch == '`'), line.count(('\`'.equals)));
 		line = "";
 	} else if (is Paragraph block = lastBlock,
 		block.open,
@@ -170,7 +170,7 @@ void parseLine(variable String line, Block parent) {
 		}
 		line = "";
 	} else if (is FencedCode block = lastBlock, block.open) {
-		lineBlock = FencedCode(line, block.fenceLevel);
+		lineBlock = FencedCode(line, block.infoString, block.fenceLevel);
 		
 		line = "";
 	} else {


### PR DESCRIPTION
See http://spec.commonmark.org/0.26/#fenced-code-blocks

We need to be able to retain the info string so we can use it in output to do things like syntax highlighting.
